### PR TITLE
Assigning guid to client networkstreams

### DIFF
--- a/DefaultPackage/Handlers/BasicHandler.cs
+++ b/DefaultPackage/Handlers/BasicHandler.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using NetworkingCore.SharedStateObjects;
+using NetworkingCore.Messages;
 
 namespace DefaultPackage.Handlers
 {
@@ -19,22 +20,14 @@ namespace DefaultPackage.Handlers
             get { return typeof(BasicMessage); }
         }
 
-        //public override void ClientProcessMessage(IMessage message)
-        //{
-        //    Console.WriteLine(HandlerData);
-        //    message.ClientProcessMessage();
-        //}
-
-        public override void ServerProcessMessage(IMessage message, object o)
+        public override void ClientProcessMessage(BaseMessage message, ClientSharedStateObject sharedStateObj)
         {
-            Console.WriteLine(HandlerData);
-            message.ServerProcessMessage();
+            throw new NotImplementedException();
         }
 
-        public override void ClientProcessMessage(IMessage message, ClientSharedStateObject sharedStateObj)
+        public override void ServerProcessMessage(BaseMessage message, object o)
         {
-            Console.WriteLine(HandlerData);
-            message.ClientProcessMessage();
+            throw new NotImplementedException();
         }
 
         public BasicMessageHandler()

--- a/DefaultPackage/Handlers/BasicHandler.cs
+++ b/DefaultPackage/Handlers/BasicHandler.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using NetworkingCore.SharedStateObjects;
 
 namespace DefaultPackage.Handlers
 {
@@ -18,16 +19,22 @@ namespace DefaultPackage.Handlers
             get { return typeof(BasicMessage); }
         }
 
-        public override void ClientProcessMessage(IMessage message)
-        {
-            Console.WriteLine(HandlerData);
-            message.ClientProcessMessage();
-        }
+        //public override void ClientProcessMessage(IMessage message)
+        //{
+        //    Console.WriteLine(HandlerData);
+        //    message.ClientProcessMessage();
+        //}
 
         public override void ServerProcessMessage(IMessage message, object o)
         {
             Console.WriteLine(HandlerData);
             message.ServerProcessMessage();
+        }
+
+        public override void ClientProcessMessage(IMessage message, ClientSharedStateObject sharedStateObj)
+        {
+            Console.WriteLine(HandlerData);
+            message.ClientProcessMessage();
         }
 
         public BasicMessageHandler()

--- a/DefaultPackage/Handlers/SpecialHandler.cs
+++ b/DefaultPackage/Handlers/SpecialHandler.cs
@@ -4,6 +4,8 @@ using System.Linq;
 using System.Text;
 using DefaultPackage.Messages;
 using NetworkingCore;
+using NetworkingCore.Messages;
+using NetworkingCore.SharedStateObjects;
 
 namespace DefaultPackage.Handlers
 {
@@ -16,16 +18,16 @@ namespace DefaultPackage.Handlers
             get { return typeof(SpecialMessage); }
         }
 
-        public override void ClientProcessMessage(IMessage message)
+        public override void ClientProcessMessage(BaseMessage message, ClientSharedStateObject sharedStateObj)
         {
             Console.WriteLine(HandlerData);
-            message.ClientProcessMessage();
+            message.ClientProcessMessage(sharedStateObj);
         }
 
-        public override void ServerProcessMessage(IMessage message, object o)
+        public override void ServerProcessMessage(BaseMessage message, object o)
         {
             Console.WriteLine(HandlerData);
-            message.ServerProcessMessage();
+            //message.ServerProcessMessage();
         }
 
         public SpecialHandler()

--- a/DefaultPackage/Messages/BasicMessage.cs
+++ b/DefaultPackage/Messages/BasicMessage.cs
@@ -9,15 +9,11 @@ namespace DefaultPackage.Messages
     public class BasicMessage : BaseMessage
     {
         public string Data { get; set; }
-        public string Sender { get; private set; }
 
         public List<Guid> Recipients { get; set ; }
 
-        public BasicMessage(string data, string sender)
+        public BasicMessage(Guid clientID, string data) : base(clientID)
         {
-            this.Data = data;
-            this.Sender = sender;
-
         }
 
         public override void ClientProcessMessage(ClientSharedStateObject SharedStateObj)

--- a/DefaultPackage/Messages/BasicMessage.cs
+++ b/DefaultPackage/Messages/BasicMessage.cs
@@ -9,8 +9,6 @@ namespace DefaultPackage.Messages
         public string Data { get; set; }
         public string Sender { get; private set; }
 
-        Guid IMessage.Sender => throw new NotImplementedException();
-
         public List<Guid> Recipients { get; set ; }
 
         public BasicMessage(string data, string sender)

--- a/DefaultPackage/Messages/BasicMessage.cs
+++ b/DefaultPackage/Messages/BasicMessage.cs
@@ -1,10 +1,12 @@
 ﻿using NetworkingCore;
+using NetworkingCore.Messages;
 using System;
 using System.Collections.Generic;
+using NetworkingCore.SharedStateObjects;
 
 namespace DefaultPackage.Messages
 {
-    public class BasicMessage : IMessage
+    public class BasicMessage : BaseMessage
     {
         public string Data { get; set; }
         public string Sender { get; private set; }
@@ -18,12 +20,12 @@ namespace DefaultPackage.Messages
 
         }
 
-        public void ClientProcessMessage(params object[] argsList)
+        public override void ClientProcessMessage(ClientSharedStateObject SharedStateObj)
         {
             throw new NotImplementedException();
         }
 
-        public void ServerProcessMessage(params object[] argsList)
+        public override void ServerProcessMessage(ServerSharedStateObject SharedStateObj)
         {
             throw new NotImplementedException();
         }

--- a/DefaultPackage/Messages/SpecialMessage.cs
+++ b/DefaultPackage/Messages/SpecialMessage.cs
@@ -1,10 +1,12 @@
 ﻿using NetworkingCore;
+using NetworkingCore.Messages;
 using System;
 using System.Collections.Generic;
+using NetworkingCore.SharedStateObjects;
 
 namespace DefaultPackage.Messages
 {
-    public class SpecialMessage : IMessage
+    public class SpecialMessage : BaseMessage
     {
         public string Data { get; set; }
 
@@ -18,12 +20,12 @@ namespace DefaultPackage.Messages
             this.Sender = sender;
         }
 
-        public void ClientProcessMessage(params object[] argsList)
+        public override void ClientProcessMessage(ClientSharedStateObject SharedStateObj)
         {
             throw new NotImplementedException();
         }
 
-        public void ServerProcessMessage(params object[] argsList)
+        public override void ServerProcessMessage(ServerSharedStateObject SharedStateObj)
         {
             throw new NotImplementedException();
         }

--- a/DefaultPackage/Messages/SpecialMessage.cs
+++ b/DefaultPackage/Messages/SpecialMessage.cs
@@ -10,8 +10,6 @@ namespace DefaultPackage.Messages
 
         public string Sender { get; private set; }
 
-        Guid IMessage.Sender => throw new NotImplementedException();
-
         public List<Guid> Recipients { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 
         public SpecialMessage(string data, string sender)

--- a/DefaultPackage/Messages/SpecialMessage.cs
+++ b/DefaultPackage/Messages/SpecialMessage.cs
@@ -8,17 +8,14 @@ namespace DefaultPackage.Messages
 {
     public class SpecialMessage : BaseMessage
     {
-        public string Data { get; set; }
-
-        public string Sender { get; private set; }
-
-        public List<Guid> Recipients { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
-
-        public SpecialMessage(string data, string sender)
+        public SpecialMessage(Guid clientID, string data) : base(clientID)
         {
             this.Data = data;
-            this.Sender = sender;
         }
+
+        public string Data { get; set; }
+
+        public List<Guid> Recipients { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 
         public override void ClientProcessMessage(ClientSharedStateObject SharedStateObj)
         {

--- a/NetworkingCore/MessageHandler/BaseMessageHandler.cs
+++ b/NetworkingCore/MessageHandler/BaseMessageHandler.cs
@@ -1,4 +1,6 @@
-﻿ using System;
+﻿using NetworkingCore.Messages;
+using NetworkingCore.SharedStateObjects;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -14,9 +16,9 @@ namespace NetworkingCore
             get { return null; }
         }
 
-        public abstract void ClientProcessMessage(IMessage message);
+        public abstract void ClientProcessMessage(BaseMessage message, ClientSharedStateObject sharedStateObj);
 
-        public abstract void ServerProcessMessage(IMessage message, object o);
+        public abstract void ServerProcessMessage(BaseMessage message, object o);
 
     }
 }

--- a/NetworkingCore/MessageHandler/ConnectMessageHandler.cs
+++ b/NetworkingCore/MessageHandler/ConnectMessageHandler.cs
@@ -1,29 +1,25 @@
-﻿using NetworkingCore.SharedStateObjects;
+﻿using NetworkingCore.Messages;
+using NetworkingCore.SharedStateObjects;
 using System;
 
 namespace NetworkingCore
 {
     public class ConnectMessageHandler : BaseMessageHandler
     {
-        public Guid ClientGuid { get; set; }
-
         public override Type HandledMessageType
         {
             get { return typeof(ConnectMessage); }
         }
 
-        public override void ClientProcessMessage(IMessage message)
+        public override void ClientProcessMessage(BaseMessage message, ClientSharedStateObject sharedStateObj)
         {
-            throw new NotImplementedException();
-            /* assign guid to the client
-             * client will then echo back the guid to the server
-             */
+            //sharedStateObj.ClientID = message.c
+            message.ClientProcessMessage(sharedStateObj);
         }
 
         public override void ServerProcessMessage(IMessage message, object o)
         {
-            /* Here we will send the client it's guid
-             */
+            throw new NotImplementedException();
         }
     }
 }

--- a/NetworkingCore/MessageHandler/ConnectMessageHandler.cs
+++ b/NetworkingCore/MessageHandler/ConnectMessageHandler.cs
@@ -24,13 +24,6 @@ namespace NetworkingCore
         {
             /* Here we will send the client it's guid
              */
-
-            var SharedStateObj = (ServerSharedStateObject)o;
-
-            lock (SharedStateObj.ClientQueue)
-            {
-                SharedStateObj.ClientQueue.Add(Guid.NewGuid,)
-            }
         }
     }
 }

--- a/NetworkingCore/MessageHandler/ConnectMessageHandler.cs
+++ b/NetworkingCore/MessageHandler/ConnectMessageHandler.cs
@@ -17,7 +17,7 @@ namespace NetworkingCore
             message.ClientProcessMessage(sharedStateObj);
         }
 
-        public override void ServerProcessMessage(IMessage message, object o)
+        public override void ServerProcessMessage(BaseMessage message, object o)
         {
             throw new NotImplementedException();
         }

--- a/NetworkingCore/MessageHandler/ConnectMessageHandler.cs
+++ b/NetworkingCore/MessageHandler/ConnectMessageHandler.cs
@@ -27,6 +27,10 @@ namespace NetworkingCore
 
             var SharedStateObj = (ServerSharedStateObject)o;
 
+            lock (SharedStateObj.ClientQueue)
+            {
+                SharedStateObj.ClientQueue.Add(Guid.NewGuid,)
+            }
         }
     }
 }

--- a/NetworkingCore/Messages/BaseMessage.cs
+++ b/NetworkingCore/Messages/BaseMessage.cs
@@ -8,7 +8,13 @@ namespace NetworkingCore.Messages
 {
     abstract public class BaseMessage
     {
+        public Guid Sender { get; private set; }
         abstract public void ClientProcessMessage(ClientSharedStateObject SharedStateObj);
         abstract public void ServerProcessMessage(ServerSharedStateObject SharedStateObj);
+
+        public BaseMessage(Guid clientID)
+        {
+            this.Sender = clientID;
+        }
     }
 }

--- a/NetworkingCore/Messages/BaseMessage.cs
+++ b/NetworkingCore/Messages/BaseMessage.cs
@@ -1,0 +1,14 @@
+﻿using NetworkingCore.SharedStateObjects;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace NetworkingCore.Messages
+{
+    abstract public class BaseMessage
+    {
+        abstract public void ClientProcessMessage(ClientSharedStateObject SharedStateObj);
+        abstract public void ServerProcessMessage(ServerSharedStateObject SharedStateObj);
+    }
+}

--- a/NetworkingCore/Messages/ConnectMessage.cs
+++ b/NetworkingCore/Messages/ConnectMessage.cs
@@ -10,10 +10,8 @@ namespace NetworkingCore
     public class ConnectMessage : IMessage
     {
         public string Sender { get; private set; }
-        public List<Guid> Recipients { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 
-        Guid IMessage.Sender => throw new NotImplementedException();
-
+        public Guid clientID { get; set; }
 
         public void ClientProcessMessage(params object[] argsList)
         {

--- a/NetworkingCore/Messages/ConnectMessage.cs
+++ b/NetworkingCore/Messages/ConnectMessage.cs
@@ -14,6 +14,7 @@ namespace NetworkingCore
 
         Guid IMessage.Sender => throw new NotImplementedException();
 
+
         public void ClientProcessMessage(params object[] argsList)
         {
             throw new NotImplementedException();

--- a/NetworkingCore/Messages/ConnectMessage.cs
+++ b/NetworkingCore/Messages/ConnectMessage.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using NetworkingCore.Messages;
+using NetworkingCore.SharedStateObjects;
+using System;
 using System.Collections.Generic;
 
 namespace NetworkingCore
@@ -7,18 +9,16 @@ namespace NetworkingCore
     /// The connect message is the first message that will be received after opening a connection with a client.
     /// The client will send this message to the server and the server will reply back with 
     /// </summary>
-    public class ConnectMessage : IMessage
+    public class ConnectMessage : BaseMessage
     {
-        public string Sender { get; private set; }
-
         public Guid clientID { get; set; }
 
-        public void ClientProcessMessage(params object[] argsList)
+        public override void ClientProcessMessage(ClientSharedStateObject SharedStateObj)
         {
-            throw new NotImplementedException();
+            //SharedStateObj.ClientID = 
         }
 
-        public void ServerProcessMessage(params object[] argsList)
+        public override void ServerProcessMessage(ServerSharedStateObject SharedStateObj)
         {
             throw new NotImplementedException();
         }

--- a/NetworkingCore/Messages/ConnectMessage.cs
+++ b/NetworkingCore/Messages/ConnectMessage.cs
@@ -11,6 +11,11 @@ namespace NetworkingCore
     /// </summary>
     public class ConnectMessage : BaseMessage
     {
+        public ConnectMessage(Guid serverID, Guid clientID) : base(serverID)
+        {
+            this.clientID = clientID;
+        }
+
         public Guid clientID { get; set; }
 
         public override void ClientProcessMessage(ClientSharedStateObject SharedStateObj)

--- a/NetworkingCore/Messages/ConnectMessage.cs
+++ b/NetworkingCore/Messages/ConnectMessage.cs
@@ -15,7 +15,7 @@ namespace NetworkingCore
 
         public override void ClientProcessMessage(ClientSharedStateObject SharedStateObj)
         {
-            //SharedStateObj.ClientID = 
+            SharedStateObj.ClientID = this.clientID;
         }
 
         public override void ServerProcessMessage(ServerSharedStateObject SharedStateObj)

--- a/NetworkingCore/Messages/IMessage.cs
+++ b/NetworkingCore/Messages/IMessage.cs
@@ -7,8 +7,6 @@ namespace NetworkingCore
 {
     public interface IMessage
     {
-        Guid Sender { get; }
-        List<Guid> Recipients { get; set; }
         void ClientProcessMessage(params object[] argsList);
         void ServerProcessMessage(params object[] argsList);
     }

--- a/NetworkingCore/Messages/ServerMessageWrapper.cs
+++ b/NetworkingCore/Messages/ServerMessageWrapper.cs
@@ -7,8 +7,8 @@ namespace NetworkingCore.Messages
 {
     public sealed class ServerMessageWrapper
     {
-        public IMessage MessageToSend { get; private set; }
-        public List<Guid> TargetClients { get; private set; }
+        public IMessage MessageToSend { get; set; }
+        public List<Guid> TargetClients { get; set; }
 
         /// <summary>
         /// Creates a new instance of the ServerMessageWrapper Class.
@@ -19,6 +19,10 @@ namespace NetworkingCore.Messages
         {
             this.MessageToSend = MessageToSend;
             this.TargetClients = TargetClients;
+        }
+
+        public ServerMessageWrapper()
+        {
         }
     }
 }

--- a/NetworkingCore/Messages/ServerMessageWrapper.cs
+++ b/NetworkingCore/Messages/ServerMessageWrapper.cs
@@ -7,7 +7,7 @@ namespace NetworkingCore.Messages
 {
     public sealed class ServerMessageWrapper
     {
-        public IMessage MessageToSend { get; set; }
+        public BaseMessage MessageToSend { get; set; }
         public List<Guid> TargetClients { get; set; }
 
         /// <summary>
@@ -15,7 +15,7 @@ namespace NetworkingCore.Messages
         /// </summary>
         /// <param name="MessageToSend">This is the IMessage that is going to be sent.</param>
         /// <param name="TargetClients">This is the list of clients that will receive the message.</param>
-        public ServerMessageWrapper(IMessage MessageToSend, List<Guid> TargetClients)
+        public ServerMessageWrapper(BaseMessage MessageToSend, List<Guid> TargetClients)
         {
             this.MessageToSend = MessageToSend;
             this.TargetClients = TargetClients;

--- a/NetworkingCore/NetworkingCore.csproj
+++ b/NetworkingCore/NetworkingCore.csproj
@@ -39,6 +39,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MessageHandler\BaseMessageHandler.cs" />
+    <Compile Include="Messages\BaseMessage.cs" />
     <Compile Include="Messages\ConnectMessage.cs" />
     <Compile Include="MessageHandler\ConnectMessageHandler.cs" />
     <Compile Include="Messages\IMessage.cs" />

--- a/NetworkingCore/SharedStateObjects/ClientSharedStateObject.cs
+++ b/NetworkingCore/SharedStateObjects/ClientSharedStateObject.cs
@@ -12,7 +12,7 @@ namespace NetworkingCore.SharedStateObjects
         public bool ContinueProcess;
         public AutoResetEvent Ev;
         public Queue<BaseMessage> InBoundMessageQueue;
-        public Queue<IMessage> OutBoundMessageQueue;
+        public Queue<BaseMessage> OutBoundMessageQueue;
         public Guid ClientID;
     }
 }

--- a/NetworkingCore/SharedStateObjects/ClientSharedStateObject.cs
+++ b/NetworkingCore/SharedStateObjects/ClientSharedStateObject.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using NetworkingCore.Messages;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -10,7 +11,8 @@ namespace NetworkingCore.SharedStateObjects
     {
         public bool ContinueProcess;
         public AutoResetEvent Ev;
-        public Queue<IMessage> InBoundMessageQueue;
+        public Queue<BaseMessage> InBoundMessageQueue;
         public Queue<IMessage> OutBoundMessageQueue;
+        public Guid ClientID;
     }
 }

--- a/NetworkingCore/SharedStateObjects/ServerSharedStateObject.cs
+++ b/NetworkingCore/SharedStateObjects/ServerSharedStateObject.cs
@@ -13,7 +13,7 @@ namespace NetworkingCore.SharedStateObjects
         public bool ContinueProcess;
         public int NumberOfClients;
         public AutoResetEvent Ev;
-        public Queue<IMessage> InBoundMessageQueue;
+        public Queue<BaseMessage> InBoundMessageQueue;
         public Dictionary<Guid, NetworkStream> ClientQueue;
         public Queue<ServerMessageWrapper> OutBoundMessageQueue;
     }

--- a/NetworkingCore/SharedStateObjects/ServerSharedStateObject.cs
+++ b/NetworkingCore/SharedStateObjects/ServerSharedStateObject.cs
@@ -13,7 +13,7 @@ namespace NetworkingCore.SharedStateObjects
         public int NumberOfClients;
         public AutoResetEvent Ev;
         public Queue<IMessage> InBoundMessageQueue;
-        public Dictionary<Guid, TcpClient> ClientQueue;
+        public Dictionary<Guid, NetworkStream> ClientQueue;
         public Queue<IMessage> OutBoundMessageQueue;
     }
 }

--- a/NetworkingCore/SharedStateObjects/ServerSharedStateObject.cs
+++ b/NetworkingCore/SharedStateObjects/ServerSharedStateObject.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using NetworkingCore.Messages;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Sockets;
@@ -14,6 +15,6 @@ namespace NetworkingCore.SharedStateObjects
         public AutoResetEvent Ev;
         public Queue<IMessage> InBoundMessageQueue;
         public Dictionary<Guid, NetworkStream> ClientQueue;
-        public Queue<IMessage> OutBoundMessageQueue;
+        public Queue<ServerMessageWrapper> OutBoundMessageQueue;
     }
 }

--- a/NetworkingCore/SharedStateObjects/ServerSharedStateObject.cs
+++ b/NetworkingCore/SharedStateObjects/ServerSharedStateObject.cs
@@ -16,5 +16,6 @@ namespace NetworkingCore.SharedStateObjects
         public Queue<BaseMessage> InBoundMessageQueue;
         public Dictionary<Guid, NetworkStream> ClientQueue;
         public Queue<ServerMessageWrapper> OutBoundMessageQueue;
+        public Guid serverID;
     }
 }

--- a/SpecialPackage/Handlers/BasicHandler.cs
+++ b/SpecialPackage/Handlers/BasicHandler.cs
@@ -1,6 +1,8 @@
 ﻿using SpecialPackage.Messages;
 using System;
 using NetworkingCore;
+using NetworkingCore.Messages;
+using NetworkingCore.SharedStateObjects;
 
 namespace SpecialPackage.Handlers
 {
@@ -25,16 +27,28 @@ namespace SpecialPackage.Handlers
             get { return typeof(BasicMessage); }
         }
 
-        public override void ClientProcessMessage(IMessage message)
+        //public override void ClientProcessMessage(IMessage message)
+        //{
+        //    Console.WriteLine(HandlerData);
+        //    message.ClientProcessMessage();
+        //}
+
+        //public override void ServerProcessMessage(IMessage message, object os)
+        //{
+        //    Console.WriteLine(HandlerData);
+        //    message.ServerProcessMessage(); 
+        //}
+
+        public override void ClientProcessMessage(BaseMessage message, ClientSharedStateObject sharedStateObj)
         {
             Console.WriteLine(HandlerData);
-            message.ClientProcessMessage();
+            message.ClientProcessMessage(sharedStateObj);
         }
 
-        public override void ServerProcessMessage(IMessage message, object os)
+        public override void ServerProcessMessage(BaseMessage message, object o)
         {
             Console.WriteLine(HandlerData);
-            message.ServerProcessMessage(); 
+            //message.ServerProcessMessage();
         }
 
         public BasicMessageHandler()

--- a/SpecialPackage/Handlers/SpecialHandler.cs
+++ b/SpecialPackage/Handlers/SpecialHandler.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using SpecialPackage.Messages;
 using NetworkingCore;
+using NetworkingCore.Messages;
+using NetworkingCore.SharedStateObjects;
 
 namespace SpecialPackage.Handlers
 {
@@ -23,16 +25,16 @@ namespace SpecialPackage.Handlers
             get { return typeof(SpecialMessage); }
         }
 
-        public override void ClientProcessMessage(IMessage message)
+        public override void ClientProcessMessage(BaseMessage message, ClientSharedStateObject sharedStateObj)
         {
             Console.WriteLine(HandlerData);
-            message.ClientProcessMessage();
+            message.ClientProcessMessage(sharedStateObj);
         }
 
-        public override void ServerProcessMessage(IMessage message, object o)
+        public override void ServerProcessMessage(BaseMessage message, object o)
         {
             Console.WriteLine(HandlerData);
-            message.ServerProcessMessage();
+            //message.ServerProcessMessage();
         }
 
         public SpecialHandler()

--- a/SpecialPackage/Messages/BasicMessage.cs
+++ b/SpecialPackage/Messages/BasicMessage.cs
@@ -10,8 +10,6 @@ namespace SpecialPackage.Messages
 
         public string Sender { get; private set; }
 
-        Guid IMessage.Sender => throw new NotImplementedException();
-
         public List<Guid> Recipients { get; set; }
 
         public BasicMessage(string data, string sender)

--- a/SpecialPackage/Messages/BasicMessage.cs
+++ b/SpecialPackage/Messages/BasicMessage.cs
@@ -1,10 +1,12 @@
 ﻿using NetworkingCore;
+using NetworkingCore.Messages;
 using System;
 using System.Collections.Generic;
+using NetworkingCore.SharedStateObjects;
 
 namespace SpecialPackage.Messages
 {
-    public class BasicMessage : IMessage
+    public class BasicMessage : BaseMessage
     {
         public string Data { get; set; }
 
@@ -18,12 +20,12 @@ namespace SpecialPackage.Messages
             this.Sender = data;
         }
 
-        public void ClientProcessMessage(params object[] argsList)
+        public override void ClientProcessMessage(ClientSharedStateObject SharedStateObj)
         {
             throw new NotImplementedException();
         }
 
-        public void ServerProcessMessage(params object[] argsList)
+        public override void ServerProcessMessage(ServerSharedStateObject SharedStateObj)
         {
             Console.WriteLine(Data);
         }

--- a/SpecialPackage/Messages/BasicMessage.cs
+++ b/SpecialPackage/Messages/BasicMessage.cs
@@ -8,17 +8,12 @@ namespace SpecialPackage.Messages
 {
     public class BasicMessage : BaseMessage
     {
-        public string Data { get; set; }
-
-        public string Sender { get; private set; }
-
-        public List<Guid> Recipients { get; set; }
-
-        public BasicMessage(string data, string sender)
+        public BasicMessage(Guid clientID, string data) : base(clientID)
         {
             this.Data = data;
-            this.Sender = data;
         }
+
+        public string Data { get; set; }
 
         public override void ClientProcessMessage(ClientSharedStateObject SharedStateObj)
         {

--- a/SpecialPackage/Messages/SpecialMessage.cs
+++ b/SpecialPackage/Messages/SpecialMessage.cs
@@ -1,10 +1,12 @@
 ﻿using NetworkingCore;
+using NetworkingCore.Messages;
 using System;
 using System.Collections.Generic;
+using NetworkingCore.SharedStateObjects;
 
 namespace SpecialPackage.Messages
 {
-    public class SpecialMessage : IMessage
+    public class SpecialMessage : BaseMessage
     {
         public string Data { get; set; }
 
@@ -18,12 +20,12 @@ namespace SpecialPackage.Messages
             this.Sender = sender;
         }
 
-        public void ClientProcessMessage(params object[] argsList)
+        public override void ClientProcessMessage(ClientSharedStateObject SharedStateObj)
         {
             throw new NotImplementedException();
         }
 
-        public void ServerProcessMessage(params object[] argsList)
+        public override void ServerProcessMessage(ServerSharedStateObject SharedStateObj)
         {
             throw new NotImplementedException();
         }

--- a/SpecialPackage/Messages/SpecialMessage.cs
+++ b/SpecialPackage/Messages/SpecialMessage.cs
@@ -10,8 +10,6 @@ namespace SpecialPackage.Messages
 
         public string Sender { get; private set; }
 
-        Guid IMessage.Sender => throw new NotImplementedException();
-
         public List<Guid> Recipients { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 
         public SpecialMessage(string data, string sender)

--- a/SpecialPackage/Messages/SpecialMessage.cs
+++ b/SpecialPackage/Messages/SpecialMessage.cs
@@ -10,14 +10,9 @@ namespace SpecialPackage.Messages
     {
         public string Data { get; set; }
 
-        public string Sender { get; private set; }
-
-        public List<Guid> Recipients { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
-
-        public SpecialMessage(string data, string sender)
+        public SpecialMessage(Guid clientID, string data) : base(clientID)
         {
             this.Data = data;
-            this.Sender = sender;
         }
 
         public override void ClientProcessMessage(ClientSharedStateObject SharedStateObj)

--- a/anotherNetworkingTest.sln
+++ b/anotherNetworkingTest.sln
@@ -9,16 +9,13 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "anotherNetworkingTest", "an
 		{97C05238-E983-4F9E-8C86-D71E5FDA62B2} = {97C05238-E983-4F9E-8C86-D71E5FDA62B2}
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "clientTesting", "..\clientTesting\clientTesting\clientTesting.csproj", "{78950806-884B-4A22-99FA-A2B0D4BBCFC0}"
-	ProjectSection(ProjectDependencies) = postProject
-		{97C05238-E983-4F9E-8C86-D71E5FDA62B2} = {97C05238-E983-4F9E-8C86-D71E5FDA62B2}
-	EndProjectSection
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DefaultPackage", "DefaultPackage\DefaultPackage.csproj", "{97C05238-E983-4F9E-8C86-D71E5FDA62B2}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SpecialPackage", "SpecialPackage\SpecialPackage.csproj", "{B0F3832E-8DD8-41F4-AB1A-6FBCD16B7BD1}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NetworkingCore", "NetworkingCore\NetworkingCore.csproj", "{B79FF125-0D80-4A55-B796-E46A5AC46914}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "clientTesting", "clientTesting\clientTesting.csproj", "{78950806-884B-4A22-99FA-A2B0D4BBCFC0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -30,10 +27,6 @@ Global
 		{4A5496FD-BC4E-4CBF-88E9-74233107D7D5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4A5496FD-BC4E-4CBF-88E9-74233107D7D5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4A5496FD-BC4E-4CBF-88E9-74233107D7D5}.Release|Any CPU.Build.0 = Release|Any CPU
-		{78950806-884B-4A22-99FA-A2B0D4BBCFC0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{78950806-884B-4A22-99FA-A2B0D4BBCFC0}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{78950806-884B-4A22-99FA-A2B0D4BBCFC0}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{78950806-884B-4A22-99FA-A2B0D4BBCFC0}.Release|Any CPU.Build.0 = Release|Any CPU
 		{97C05238-E983-4F9E-8C86-D71E5FDA62B2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{97C05238-E983-4F9E-8C86-D71E5FDA62B2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{97C05238-E983-4F9E-8C86-D71E5FDA62B2}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -46,6 +39,10 @@ Global
 		{B79FF125-0D80-4A55-B796-E46A5AC46914}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B79FF125-0D80-4A55-B796-E46A5AC46914}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B79FF125-0D80-4A55-B796-E46A5AC46914}.Release|Any CPU.Build.0 = Release|Any CPU
+		{78950806-884B-4A22-99FA-A2B0D4BBCFC0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{78950806-884B-4A22-99FA-A2B0D4BBCFC0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{78950806-884B-4A22-99FA-A2B0D4BBCFC0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{78950806-884B-4A22-99FA-A2B0D4BBCFC0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/anotherNetworkingTest/Server/Server.cs
+++ b/anotherNetworkingTest/Server/Server.cs
@@ -60,6 +60,13 @@ namespace anotherNetworkingTest.Server
                     {
                         Console.WriteLine("Client# {0} accepted!", ++ClientNbr);
                         //An incoming connection needs to be processed
+                        /* Send the server connect messages and handle the response?
+                         */
+
+                        var connectionMessage = new ConnectMessage();
+                        connectionMessage.
+                        handler.GetStream().Write();
+
                         ClientHandler client = new ClientHandler(handler);
                         ThreadPool.QueueUserWorkItem(new WaitCallback(client.Process), SharedStateObj);
 
@@ -85,7 +92,6 @@ namespace anotherNetworkingTest.Server
             Console.WriteLine("\nHit enter to continue...");
             Console.Read();
         }
-        
     }
 
     class MessageQueueProcessor

--- a/anotherNetworkingTest/Server/Server.cs
+++ b/anotherNetworkingTest/Server/Server.cs
@@ -32,7 +32,7 @@ namespace anotherNetworkingTest.Server
                 ContinueProcess = true,
                 NumberOfClients = 0,
                 Ev = new AutoResetEvent(false),
-                InBoundMessageQueue = new Queue<IMessage>(),
+                InBoundMessageQueue = new Queue<BaseMessage>(),
                 ClientQueue = new Dictionary<Guid, NetworkStream>(),
                 OutBoundMessageQueue = new Queue<ServerMessageWrapper>()
             };
@@ -218,7 +218,7 @@ namespace anotherNetworkingTest.Server
             //incoming data from client
             string data = null;
 
-            IMessage receivedMessage = null;
+            BaseMessage receivedMessage = null;
 
             //data buffer coming in
             byte[] bytes;
@@ -256,7 +256,7 @@ namespace anotherNetworkingTest.Server
                         {
                             data = Encoding.ASCII.GetString(bytes, 0, BytesRead);
 
-                            receivedMessage = (IMessage)JsonConvert.DeserializeObject(data, new JsonSerializerSettings() { TypeNameHandling = TypeNameHandling.Auto });
+                            receivedMessage = (BaseMessage)JsonConvert.DeserializeObject(data, new JsonSerializerSettings() { TypeNameHandling = TypeNameHandling.Auto });
 
                             // show the data in the console
                             Console.WriteLine("Text Received: {0}", data);

--- a/clientTesting/Program.cs
+++ b/clientTesting/Program.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Sockets;
+using System.Text;
+using DefaultPackage.Messages;
+using Newtonsoft.Json;
+using System.Net;
+
+namespace clientTesting
+{
+    class Program
+    {
+        private const int portNum = 55555;
+
+        static void Main(string[] args)
+        {
+            IPAddress address;
+
+            try
+            {
+                address = IPAddress.Parse("127.0.0.1");
+            }
+            catch (Exception e)
+            {
+
+                throw;
+            }
+
+            client.Run(address,portNum);
+        }
+    }
+}

--- a/clientTesting/Properties/AssemblyInfo.cs
+++ b/clientTesting/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("clientTesting")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("clientTesting")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("78950806-884b-4a22-99fa-a2b0d4bbcfc0")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/clientTesting/client.cs
+++ b/clientTesting/client.cs
@@ -27,11 +27,11 @@ namespace clientTesting
                 ContinueProcess = true,
                 Ev = new AutoResetEvent(false),
                 InBoundMessageQueue = new Queue<BaseMessage>(),
-                OutBoundMessageQueue = new Queue<IMessage>()
+                OutBoundMessageQueue = new Queue<BaseMessage>()
             };
 
             TcpClient tcpClient = new TcpClient();
-            IMessage message = null;
+            BaseMessage message = null;
             try
             {
                 tcpClient.Connect(address, portNum);

--- a/clientTesting/client.cs
+++ b/clientTesting/client.cs
@@ -12,12 +12,13 @@ using System.Threading;
 using System.Reflection;
 using NetworkingCore.SharedStateObjects;
 using NetworkingCore;
+using NetworkingCore.Messages;
 
 namespace clientTesting
 {
     public static class client
     {
-        private static ClientSharedStateObject SharedStateObj;
+        public static ClientSharedStateObject SharedStateObj;
 
         public static void Run(IPAddress address, int portNum)
         {
@@ -25,7 +26,7 @@ namespace clientTesting
             {
                 ContinueProcess = true,
                 Ev = new AutoResetEvent(false),
-                InBoundMessageQueue = new Queue<IMessage>(),
+                InBoundMessageQueue = new Queue<BaseMessage>(),
                 OutBoundMessageQueue = new Queue<IMessage>()
             };
 
@@ -121,7 +122,7 @@ namespace clientTesting
 
             string data = null;
 
-            IMessage receivedMessage = null;
+            BaseMessage receivedMessage = null;
 
             byte[] bytes;
 
@@ -144,7 +145,7 @@ namespace clientTesting
                         {
                             data = Encoding.ASCII.GetString(bytes, 0, bytesRead);
 
-                            receivedMessage = (IMessage)JsonConvert.DeserializeObject(data, new JsonSerializerSettings() { TypeNameHandling = TypeNameHandling.Auto });
+                            receivedMessage = (BaseMessage)JsonConvert.DeserializeObject(data, new JsonSerializerSettings() { TypeNameHandling = TypeNameHandling.Auto });
 
                             lock (sharedStateObj.InBoundMessageQueue)
                             {
@@ -214,7 +215,7 @@ namespace clientTesting
                             {
                                 foreach (var handler in handlerList[item.GetType()])
                                 {
-                                    handler.ClientProcessMessage(item);
+                                    handler.ClientProcessMessage(item, SharedStateObj);
                                 }
                             }
                         }

--- a/clientTesting/client.cs
+++ b/clientTesting/client.cs
@@ -1,0 +1,266 @@
+﻿//using DefaultPackage.Messages;
+using SpecialPackage.Messages;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Sockets;
+using System.Text;
+using System.Net;
+using System.Threading;
+using System.Reflection;
+using NetworkingCore.SharedStateObjects;
+using NetworkingCore;
+
+namespace clientTesting
+{
+    public static class client
+    {
+        private static ClientSharedStateObject SharedStateObj;
+
+        public static void Run(IPAddress address, int portNum)
+        {
+            SharedStateObj = new ClientSharedStateObject()
+            {
+                ContinueProcess = true,
+                Ev = new AutoResetEvent(false),
+                InBoundMessageQueue = new Queue<IMessage>(),
+                OutBoundMessageQueue = new Queue<IMessage>()
+            };
+
+            TcpClient tcpClient = new TcpClient();
+            IMessage message = null;
+            try
+            {
+                tcpClient.Connect(address, portNum);
+
+                clientListener listener = new clientListener(tcpClient);
+                ThreadPool.QueueUserWorkItem(new WaitCallback(listener.Listen), SharedStateObj);
+
+                clientMessageHandler messageHandler = new clientMessageHandler(tcpClient);
+                ThreadPool.QueueUserWorkItem(new WaitCallback(messageHandler.ProcessMessages), SharedStateObj);
+
+                clientMessageSender messageSender = new clientMessageSender(tcpClient);
+                ThreadPool.QueueUserWorkItem(new WaitCallback(messageSender.SendMessages), SharedStateObj);
+
+                NetworkStream networkStream = tcpClient.GetStream();
+
+                if (networkStream.CanWrite && networkStream.CanRead)
+                {
+                    string DataToSend = string.Empty;
+
+                    while (!DataToSend.Equals("quit"))
+                    {
+                        Console.WriteLine("\nType a text to be sent.");
+                        DataToSend = Console.ReadLine();
+
+                        
+
+                        if (DataToSend.Length.Equals(0))
+                        {
+                            break;
+                        }
+
+                        if(!DataToSend.Equals("special"))
+                        {
+                            message = new BasicMessage (DataToSend, tcpClient.Client.LocalEndPoint.ToString());
+                        }
+                        else
+                        {
+                            message = new SpecialMessage(DataToSend, tcpClient.Client.LocalEndPoint.ToString());
+                        }
+
+                        lock (SharedStateObj.OutBoundMessageQueue)
+                        {
+                            SharedStateObj.OutBoundMessageQueue.Enqueue(message);
+                        }
+                    }
+                    networkStream.Close();
+                    tcpClient.Close();
+                }
+                else if (!networkStream.CanRead)
+                {
+                    Console.WriteLine("You can not write data to this stream");
+                    tcpClient.Close();
+                }
+                else if (!networkStream.CanWrite)
+                {
+                    Console.WriteLine("You can not read data from this stream");
+                    tcpClient.Close();
+                }
+            }
+            catch (SocketException)
+            {
+                Console.WriteLine("Server not available!");
+            }
+            catch (IOException)
+            {
+                Console.WriteLine("Server not available!");
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e.ToString());
+            }
+        }
+    }
+
+    class clientListener
+    {
+        public TcpClient ClientSocket { get; set; }
+
+        public clientListener(TcpClient clientSocket)
+        {
+            this.ClientSocket = clientSocket;
+        }
+
+
+        public void Listen(Object o)
+        {
+            ClientSharedStateObject sharedStateObj = (ClientSharedStateObject)o;
+
+            string data = null;
+
+            IMessage receivedMessage = null;
+
+            byte[] bytes;
+
+            if(ClientSocket != null)
+            {
+                NetworkStream networkStream = ClientSocket.GetStream();
+                ClientSocket.ReceiveTimeout = 100;
+
+                while (sharedStateObj.ContinueProcess)
+                {
+                    bytes = new byte[ClientSocket.ReceiveBufferSize];
+                    try
+                    {
+                        int bytesRead;
+                        lock (networkStream)
+                        {
+                            bytesRead = networkStream.Read(bytes, 0, (int)ClientSocket.ReceiveBufferSize);
+                        }
+                        if(bytesRead > 0)
+                        {
+                            data = Encoding.ASCII.GetString(bytes, 0, bytesRead);
+
+                            receivedMessage = (IMessage)JsonConvert.DeserializeObject(data, new JsonSerializerSettings() { TypeNameHandling = TypeNameHandling.Auto });
+
+                            lock (sharedStateObj.InBoundMessageQueue)
+                            {
+                                sharedStateObj.InBoundMessageQueue.Enqueue(receivedMessage);
+                            }
+                        }
+                    }
+                    catch (IOException) { } // Timeout 
+                    catch (SocketException)
+                    {
+                        Console.WriteLine("Socket is broken.");
+                        break;
+                    }
+                    Thread.Sleep(200);
+                }
+            }
+        }
+    }
+
+    class clientMessageHandler
+    {
+        TcpClient clientSocket;
+
+        public clientMessageHandler(TcpClient clientSocket)
+        {
+            this.clientSocket = clientSocket;
+        }
+
+        public void ProcessMessages(object o)
+        {
+            ClientSharedStateObject SharedStateObj = (ClientSharedStateObject)o;
+
+            Dictionary<Type, List<BaseMessageHandler>> handlerList = new Dictionary<Type, List<BaseMessageHandler>>();
+
+            var holder = Assembly.LoadFrom(AppDomain.CurrentDomain.BaseDirectory + "DefaultPackage.dll").GetTypes().ToList();
+            holder.AddRange(Assembly.LoadFrom(AppDomain.CurrentDomain.BaseDirectory + "SpecialPackage.dll").GetTypes().ToList());
+            holder.AddRange(Assembly.LoadFrom(AppDomain.CurrentDomain.BaseDirectory + "NetworkingCore.dll").GetTypes().ToList());
+
+            List<BaseMessageHandler> handlerHolder = new List<BaseMessageHandler>();
+
+            foreach (var item in holder)
+            {
+                if (item.BaseType != null && item.BaseType.Equals(typeof(BaseMessageHandler)) && !item.GetConstructor(Type.EmptyTypes).Equals(null))
+                {
+                    handlerHolder.Add((BaseMessageHandler)Activator.CreateInstance(item));
+                }
+            }
+
+            foreach (var item in handlerHolder)
+            {
+                if(!handlerList.Keys.Contains(item.HandledMessageType))
+                {
+                    handlerList.Add(item.HandledMessageType, new List<BaseMessageHandler>());
+                }
+                handlerList[item.HandledMessageType].Add(item);
+            }
+
+            while (SharedStateObj.ContinueProcess)
+            {
+                if(SharedStateObj.InBoundMessageQueue.Count > 0)
+                {
+                    lock (SharedStateObj.InBoundMessageQueue)
+                    {
+                        foreach (var item in SharedStateObj.InBoundMessageQueue)
+                        {
+                            if (handlerList.Keys.Contains(item.GetType()))
+                            {
+                                foreach (var handler in handlerList[item.GetType()])
+                                {
+                                    handler.ClientProcessMessage(item);
+                                }
+                            }
+                        }
+
+                        SharedStateObj.InBoundMessageQueue.Clear();
+                    }
+                }
+            }
+        }
+    }
+
+    class clientMessageSender
+    {
+        NetworkStream clientStream;
+
+        public clientMessageSender(TcpClient clientSocket)
+        {
+            this.clientStream = clientSocket.GetStream();
+        }
+
+        public void SendMessages(object o)
+        {
+            ClientSharedStateObject SharedStateObj = (ClientSharedStateObject)o;
+
+            while (SharedStateObj.ContinueProcess)
+            {
+                if (SharedStateObj.OutBoundMessageQueue.Count > 0)
+                {
+                    lock (SharedStateObj.OutBoundMessageQueue)
+                    {
+                        foreach (var message in SharedStateObj.OutBoundMessageQueue)
+                        {
+                            lock (clientStream)
+                            {
+                                var jsonMessage = JsonConvert.SerializeObject(message, new JsonSerializerSettings() { TypeNameHandling = TypeNameHandling.Objects });
+
+                                Byte[] sendBytes = Encoding.ASCII.GetBytes(jsonMessage);
+                                clientStream.Write(sendBytes, 0, sendBytes.Length);
+                            }
+                        }
+
+                        SharedStateObj.OutBoundMessageQueue.Clear();
+                    }
+                }
+            }
+            clientStream.Close();
+        }
+    }
+}

--- a/clientTesting/client.cs
+++ b/clientTesting/client.cs
@@ -65,17 +65,18 @@ namespace clientTesting
 
                         if(!DataToSend.Equals("special"))
                         {
-                            message = new BasicMessage (DataToSend, tcpClient.Client.LocalEndPoint.ToString());
+                            message = new BasicMessage (SharedStateObj.ClientID, DataToSend);
                         }
                         else
                         {
-                            message = new SpecialMessage(DataToSend, tcpClient.Client.LocalEndPoint.ToString());
+                            message = new SpecialMessage(SharedStateObj.ClientID, DataToSend);
                         }
 
                         lock (SharedStateObj.OutBoundMessageQueue)
                         {
                             SharedStateObj.OutBoundMessageQueue.Enqueue(message);
                         }
+                        Thread.Sleep(100);
                     }
                     networkStream.Close();
                     tcpClient.Close();
@@ -223,6 +224,7 @@ namespace clientTesting
                         SharedStateObj.InBoundMessageQueue.Clear();
                     }
                 }
+                Thread.Sleep(100);
             }
         }
     }
@@ -260,6 +262,7 @@ namespace clientTesting
                         SharedStateObj.OutBoundMessageQueue.Clear();
                     }
                 }
+                Thread.Sleep(100);
             }
             clientStream.Close();
         }

--- a/clientTesting/clientTesting.csproj
+++ b/clientTesting/clientTesting.csproj
@@ -1,0 +1,67 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{78950806-884B-4A22-99FA-A2B0D4BBCFC0}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>clientTesting</RootNamespace>
+    <AssemblyName>clientTesting</AssemblyName>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\anotherNetworkingTest\packages\Newtonsoft.Json.10.0.3\lib\net35\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="client.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\anotherNetworkingTest\DefaultPackage\DefaultPackage.csproj">
+      <Project>{97c05238-e983-4f9e-8c86-d71e5fda62b2}</Project>
+      <Name>DefaultPackage</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\anotherNetworkingTest\NetworkingCore\NetworkingCore.csproj">
+      <Project>{b79ff125-0d80-4a55-b796-e46a5ac46914}</Project>
+      <Name>NetworkingCore</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\anotherNetworkingTest\SpecialPackage\SpecialPackage.csproj">
+      <Project>{b0f3832e-8dd8-41f4-ab1a-6fbcd16b7bd1}</Project>
+      <Name>SpecialPackage</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/clientTesting/packages.config
+++ b/clientTesting/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net35" />
+</packages>


### PR DESCRIPTION
The purpose of this branch was to get the server to be able to identify individual clients.  We did this by assigning a guid to each client.  Client ID's are stored client and server side.  The server can send messages to individual clients by using their ID on the dictionary of clients to get the network stream attached to them.